### PR TITLE
build: Upgrade the base version of Ubuntu

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-rock:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-rock:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Upgrades the base version of Ubuntu.

This is required because the `scan-rock.yaml` workflow doesn't work on older versions ([it claims that docker is too old](https://github.com/canonical/lego-rock/actions/runs/13058486613/job/36435673662)).

It's probably not a bad idea to update them all anyway.

Tested and working here: https://github.com/canonical/lego-rock/actions/runs/13058870002/job/36436653479