### PR TITLE
fix: Remove default track name

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -45,6 +45,13 @@ jobs:
           echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
         if: ${{inputs.branch-name}} != ""
 
+      - name: Validate track-name
+        run: |
+          if [ -z "${{ inputs.track-name }}" ]; then
+            echo "Error: track-name cannot be empty"
+            exit 1
+          fi
+
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.3
         with:
@@ -52,12 +59,12 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ inputs.track-name }}/edge${{ steps.sanitize.outputs.sanitized }}
-        if: ${{inputs.track-name}} != ""
+        if: ${{inputs.track-name}} != "latest"
 
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.6.3
         id: channel
-        if: ${{inputs.track-name}} == ""
+        if: ${{inputs.track-name}} == "latest"
 
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.3
@@ -66,7 +73,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ steps.channel.outputs.channel }}
-        if: ${{inputs.track-name}} == ""
+        if: ${{inputs.track-name}} == "latest"
 
       - name: Publish libs
         uses: canonical/charming-actions/release-libraries@2.6.3

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -7,7 +7,6 @@ on:
   workflow_call:
     inputs:
       track-name:
-        default: latest
         description: Name of the charmhub track to publish the charm to
         type: string
       branch-name:
@@ -45,13 +44,6 @@ jobs:
           echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
         if: ${{inputs.branch-name}} != ""
 
-      - name: Validate track-name
-        run: |
-          if [ -z "${{ inputs.track-name }}" ]; then
-            echo "Error: track-name cannot be empty"
-            exit 1
-          fi
-
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.3
         with:
@@ -59,12 +51,12 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ inputs.track-name }}/edge${{ steps.sanitize.outputs.sanitized }}
-        if: ${{inputs.track-name}} != "latest"
+        if: ${{inputs.track-name}} != ""
 
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.6.3
         id: channel
-        if: ${{inputs.track-name}} == "latest"
+        if: ${{inputs.track-name}} == ""
 
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.3
@@ -73,7 +65,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ steps.channel.outputs.channel }}
-        if: ${{inputs.track-name}} == "latest"
+        if: ${{inputs.track-name}} == ""
 
       - name: Publish libs
         uses: canonical/charming-actions/release-libraries@2.6.3


### PR DESCRIPTION
`track-name` is set to a default with the value `latest`, comparing it to empty string to decide whether a track was provided by the caller will not work and both `Upload charm to Charmhub` will run within the same workflow run, the first will succeed and the second will fail with an error like `Cannot insert package. An upload with that digest (SHA3-384: '') already exists in the database. Revision of the existing package is: 335"`.
This PR fixes that by removing the default value.