### PR TITLE
Add workflows for charm multiarch build and publishing

### DIFF
--- a/.github/workflows/build-charm-multiarch.yaml
+++ b/.github/workflows/build-charm-multiarch.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
     runs-on: ${{ matrix.arch.runner }}

--- a/.github/workflows/build-charm-multiarch.yaml
+++ b/.github/workflows/build-charm-multiarch.yaml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-charm-under-test:
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: 5.21/stable
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive Charm Under Test
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm-${{ matrix.arch.arch }}
+          path: "*.charm"
+          retention-days: 5

--- a/.github/workflows/publish-charm-multiarch.yaml
+++ b/.github/workflows/publish-charm-multiarch.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
     runs-on: ${{ matrix.arch.runner }}

--- a/.github/workflows/publish-charm-multiarch.yaml
+++ b/.github/workflows/publish-charm-multiarch.yaml
@@ -1,0 +1,48 @@
+name: Publish charm
+
+on:
+  workflow_call:
+    secrets:
+      CHARMCRAFT_AUTH:
+        required: true
+
+jobs:
+  publish-charm:
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Fetch Tested Charm
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm-${{ matrix.arch.arch }}
+
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
+      - name: Upload charm to Charmhub
+        uses: canonical/charming-actions/upload-charm@2.6.3
+        with:
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: 4/edge
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log

--- a/.github/workflows/publish-charm-multiarch.yaml
+++ b/.github/workflows/publish-charm-multiarch.yaml
@@ -2,6 +2,11 @@ name: Publish charm
 
 on:
   workflow_call:
+    inputs:
+      track-name:
+        description: Name of the charmhub track to publish the charm to
+        type: string
+        required: true
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -38,7 +43,7 @@ jobs:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: 4/edge
+          channel: ${{ inputs.track-name }}/edge
 
       - name: Archive charmcraft logs
         if: failure()


### PR DESCRIPTION
Separate workflows for building and publishing charms for multiple architectures.

This could probably be parameterized in the future, and even replace publish-charm altogether at some point.