### PR TITLE
fix: Remove duplicate upload job to fix many CI

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -44,15 +44,6 @@ jobs:
           echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
         if: ${{inputs.branch-name}} != ""
 
-      - name: Upload charm to Charmhub
-        uses: canonical/charming-actions/upload-charm@2.6.3
-        with:
-          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: ${{ inputs.track-name }}/edge${{ steps.sanitize.outputs.sanitized }}
-        if: ${{inputs.track-name}} != ""
-
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.6.3
         id: channel


### PR DESCRIPTION
The duplicate upload charm job fails on the second try because the charm is already uploaded. This should fix issues publishing in a lot of our repositories.