### PR TITLE
fix: Fix charm publishing workflow for single architecture

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -40,8 +40,10 @@ jobs:
 
       - name: Sanitize the branch variable
         id: sanitize
+        env:
+          BRANCH_NAME: ${{ inputs.branch-name }}
         run: |
-          echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
+          echo sanitized=$(echo "$BRANCH_NAME" | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
         if: ${{ inputs.branch-name != '' }}
 
       - name: Upload charm to Charmhub

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -10,7 +10,7 @@ on:
         description: Name of the charmhub track to publish the charm to
         type: string
       branch-name:
-        default:
+        default: ""
         description: An additional branch name to add to the track
         type: string
     secrets:
@@ -42,7 +42,7 @@ jobs:
         id: sanitize
         run: |
           echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
-        if: ${{inputs.branch-name}} != ""
+        if: ${{ inputs.branch-name != '' }}
 
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.3
@@ -51,12 +51,12 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ inputs.track-name }}/edge${{ steps.sanitize.outputs.sanitized }}
-        if: ${{inputs.track-name}} != ""
+        if: ${{ inputs.track-name != '' }}
 
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.6.3
         id: channel
-        if: ${{inputs.track-name}} == ""
+        if: ${{ inputs.track-name == '' }}
 
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.3
@@ -65,7 +65,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ steps.channel.outputs.channel }}
-        if: ${{inputs.track-name}} == ""
+        if: ${{ inputs.track-name == '' }}
 
       - name: Publish libs
         uses: canonical/charming-actions/release-libraries@2.6.3


### PR DESCRIPTION
The code for the workflow contained many issues with the syntax of the expressions in the `if` conditionals. This PR ensures all the `if` expressions are contained in `${{ }}` to prevent errors. It also makes the default empty string explicit on the `branch-name` input. Lastly, it puts the `branch-name` input in an intermediary environment variable to prevent code injection: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

