### PR TITLE
fix: Use the right output for channel selection

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -66,7 +66,7 @@ jobs:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: ${{ steps.channel.outputs.channel }}
+          channel: ${{ steps.channel.outputs.name }}
         if: ${{ inputs.track-name == '' }}
 
       - name: Publish libs


### PR DESCRIPTION
We were using the wrong path for the output from the channel selection action. This fixes the issue.

ref: https://github.com/canonical/charming-actions/tree/main/channel