### PR TITLE
chore: Replace legacy Jira URL with Webhook URL and Token in the issues (Jira Sync) workflow

### DIFF
--- a/.github/workflows/jira-sync.yaml
+++ b/.github/workflows/jira-sync.yaml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - name: Create JIRA ticket
         env:
-           ISSUE_TITLE: ${{ github.event.issue.title }}
-           ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
-        run: |              
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
+        run: |
           if ${{ contains(github.event.*.labels.*.name, 'Bug') }}; then
             type=bug
           else
@@ -26,5 +26,9 @@ jobs:
                   --arg type "$type" \
                   --arg action '${{ github.event.action }}' \
                   '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
- 
-          curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"
+
+          curl -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'X-Automation-Webhook-Token: ${{ secrets.JIRA_WEBHOOK_TOKEN }}' \
+            --data "${data}" \
+            "${{ secrets.JIRA_WEBHOOK_URL }}"


### PR DESCRIPTION
Replace legacy Jira URL with Webhook URL and Token in the issues (Jira Sync) workflow