### PR TITLE
feat: add multiarch rock build and publishing

### DIFF
--- a/.github/workflows/build-rock-multiarch.yaml
+++ b/.github/workflows/build-rock-multiarch.yaml
@@ -1,0 +1,24 @@
+name: Build ROCK
+
+on:
+  workflow_call:
+
+jobs:
+  build-rock:
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: canonical/craft-actions/rockcraft-pack@main
+        id: rockcraft
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rock-${{ matrix.arch.arch }}
+          path: ${{ steps.rockcraft.outputs.rock }}

--- a/.github/workflows/publish-rock-multiarch.yaml
+++ b/.github/workflows/publish-rock-multiarch.yaml
@@ -40,11 +40,13 @@ jobs:
             copy \
             oci-archive:"${amd64_rock_file}" \
             docker-daemon:"ghcr.io/canonical/${image_name}:${version}-amd64"
+          docker push ghcr.io/canonical/${image_name}:${version}-amd64
           sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${arm64_rock_file}" \
             docker-daemon:"ghcr.io/canonical/${image_name}:${version}-arm64"
+          docker push ghcr.io/canonical/${image_name}:${version}-arm64
           docker manifest create ghcr.io/canonical/${image_name}:${version} \
             ghcr.io/canonical/${image_name}:${version}-amd64 \
             ghcr.io/canonical/${image_name}:${version}-arm64

--- a/.github/workflows/publish-rock-multiarch.yaml
+++ b/.github/workflows/publish-rock-multiarch.yaml
@@ -1,0 +1,55 @@
+name: Rock Publish
+
+on:
+  workflow_call:
+
+jobs:
+  publish-rock:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install rockcraft
+        run: |
+          sudo snap install rockcraft --classic --channel edge
+        
+      - uses: actions/download-artifact@v4
+        with:
+          name: rock-amd64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: rock-arm64
+
+      - name: Import and push to github package
+        run: |
+          image_name="$(yq '.name' rockcraft.yaml)"
+          version="$(cat version/VERSION)"
+          amd64_rock_file=$(ls *_amd64.rock | tail -n 1)
+          arm64_rock_file=$(ls *_arm64.rock | tail -n 1)
+          sudo rockcraft.skopeo \
+            --insecure-policy \
+            copy \
+            oci-archive:"${amd64_rock_file}" \
+            docker-daemon:"ghcr.io/canonical/${image_name}:${version}-amd64"
+          sudo rockcraft.skopeo \
+            --insecure-policy \
+            copy \
+            oci-archive:"${arm64_rock_file}" \
+            docker-daemon:"ghcr.io/canonical/${image_name}:${version}-arm64"
+          docker manifest create ghcr.io/canonical/${image_name}:${version} \
+            ghcr.io/canonical/${image_name}:${version}-amd64 \
+            ghcr.io/canonical/${image_name}:${version}-arm64
+          docker manifest push ghcr.io/canonical/${image_name}:${version}
+          docker manifest create ghcr.io/canonical/${image_name}:latest \
+            ghcr.io/canonical/${image_name}:${version}-amd64 \
+            ghcr.io/canonical/${image_name}:${version}-arm64
+          docker manifest push ghcr.io/canonical/${image_name}:latest


### PR DESCRIPTION
these workflows allow rocks to be built and published for arm. the build workflow simply calls rockcraft pack in ARM and x86 machines and produces rock-{{arch}} artifacts. the publish workflow downloads these two artifacts, and combines them into a multi arch oci image.