### PR TITLE
chore: allow to specify path to the charm root directory

### DIFF
--- a/.github/workflows/grafana-dashboard-lint-report.yaml
+++ b/.github/workflows/grafana-dashboard-lint-report.yaml
@@ -25,4 +25,4 @@ jobs:
         run: go install github.com/grafana/dashboard-linter@latest
 
       - name: Run Grafana Dashboard Lint
-        run: dashboard-linter lint ${{ github.event.inputs.path }} --strict -c grafana.lint
+        run: dashboard-linter lint ${{ inputs.path }} --strict -c grafana.lint

--- a/.github/workflows/grafana-dashboard-lint-report.yaml
+++ b/.github/workflows/grafana-dashboard-lint-report.yaml
@@ -2,7 +2,12 @@ name: Lint report
 
 on:
   workflow_call:
-
+    inputs:
+      path:
+        description: Path to the Grafana dashboards directory
+        required: false
+        type: string
+        default: src/grafana_dashboards/*
 
 jobs:
   lint-report:
@@ -10,11 +15,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+
       - name: Install Grafana Dashboard Linter
         run: go install github.com/grafana/dashboard-linter@latest
+
       - name: Run Grafana Dashboard Lint
-        run: dashboard-linter lint src/grafana_dashboards/* --strict -c grafana.lint
+        run: dashboard-linter lint ${{ github.event.inputs.path }} --strict -c grafana.lint

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -2,6 +2,12 @@ name: Lint report
 
 on:
   workflow_call:
+    inputs:
+      path:
+        description: Path to the charm's root directory
+        required: false
+        type: string
+        default: .
 
 jobs:
   lint-report:
@@ -11,6 +17,9 @@ jobs:
 
       - name: Install uv
         run: sudo snap install --classic astral-uv
+
+      - name: Change to the charm's root directory
+        run: cd ${{ github.event.inputs.path }}
 
       - name: Install tox
         run: uv tool install tox --with tox-uv

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -18,8 +18,10 @@ jobs:
       - name: Install uv
         run: sudo snap install --classic astral-uv
 
+      - name: Install tox
+        run: uv tool install tox --with tox-uv
+
       - name: Run tests using tox
         run: |
           cd ${{ inputs.path }}
-          uv tool install tox --with tox-uv
           tox -e lint

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -18,11 +18,10 @@ jobs:
       - name: Install uv
         run: sudo snap install --classic astral-uv
 
-      - name: Change to the charm's root directory
-        run: cd ${{ github.event.inputs.path }}
-
       - name: Install tox
         run: uv tool install tox --with tox-uv
 
       - name: Run tests using tox
-        run: tox -e lint
+        run: |
+          cd ${{ github.event.inputs.path }}
+          tox -e lint

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Run tests using tox
         run: |
-          cd ${{ github.event.inputs.path }}
+          cd ${{ inputs.path }}
           tox -e lint

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -7,7 +7,7 @@ on:
         description: Path to the charm's root directory
         required: false
         type: string
-        default: .
+        default: ./
 
 jobs:
   lint-report:

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -18,10 +18,8 @@ jobs:
       - name: Install uv
         run: sudo snap install --classic astral-uv
 
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
-
       - name: Run tests using tox
         run: |
           cd ${{ inputs.path }}
+          uv tool install tox --with tox-uv
           tox -e lint

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -13,6 +13,10 @@ on:
         default: ""
         description: An additional branch name to add to the track
         type: string
+      artifact-name:
+        default: built-charm
+        description: Name of the artifact to download
+        type: string
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -29,7 +33,7 @@ jobs:
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
+          name: ${{ inputs.artifact-name }}
 
       - name: Get Charm Under Test Path
         id: charm-path

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -17,13 +17,11 @@ jobs:
 
       - name: Install uv
         run: sudo snap install --classic astral-uv
-      
-      - name: Change to the charm's root directory
-        run: cd ${{ github.event.inputs.path }}
 
       - name: Install tox
         run: uv tool install tox --with tox-uv
 
       - name: Run tests using tox
-        run: tox -e static
-
+        run: |
+          cd ${{ github.event.inputs.path }}
+          tox -e static

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,7 +7,7 @@ on:
         description: Path to the charm's root directory
         required: false
         type: string
-        default: .
+        default: ./
 
 jobs:
   static-analysis:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -2,6 +2,12 @@ name: Static analysis
 
 on:
   workflow_call:
+    inputs:
+      path:
+        description: Path to the charm's root directory
+        required: false
+        type: string
+        default: .
 
 jobs:
   static-analysis:
@@ -11,6 +17,9 @@ jobs:
 
       - name: Install uv
         run: sudo snap install --classic astral-uv
+      
+      - name: Change to the charm's root directory
+        run: cd ${{ github.event.inputs.path }}
 
       - name: Install tox
         run: uv tool install tox --with tox-uv

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Run tests using tox
         run: |
-          cd ${{ github.event.inputs.path }}
+          cd ${{ inputs.path }}
           tox -e static

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,11 +18,10 @@ jobs:
       - name: Install uv
         run: sudo snap install --classic astral-uv
       
-      - name: Change to the charm's root directory
-        run: cd ${{ github.event.inputs.path }}
-
       - name: Install tox
         run: uv tool install tox --with tox-uv
 
       - name: Run tests using tox
-        run: tox -e unit
+        run: |
+          cd ${{ github.event.inputs.path }}
+          tox -e unit

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -2,6 +2,12 @@ name: Unit tests
 
 on:
   workflow_call:
+    inputs:
+      path:
+        description: Path to the charm's root directory
+        required: false
+        type: string
+        default: .
 
 jobs:
   unit-tests:
@@ -11,6 +17,9 @@ jobs:
 
       - name: Install uv
         run: sudo snap install --classic astral-uv
+      
+      - name: Change to the charm's root directory
+        run: cd ${{ github.event.inputs.path }}
 
       - name: Install tox
         run: uv tool install tox --with tox-uv

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,7 +7,7 @@ on:
         description: Path to the charm's root directory
         required: false
         type: string
-        default: .
+        default: ./
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Run tests using tox
         run: |
-          cd ${{ github.event.inputs.path }}
+          cd ${{ inputs.path }}
           tox -e unit


### PR DESCRIPTION
# Description

As we merge the Vault repositories, we want a way to be able to specify the path to the specific charm directory. Here we add a `path` input parameter to the workflows that require them. 