### PR TITLE
fix: download the charm to the provided path

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -39,13 +39,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.path }}
 
       - name: Get Charm Under Test Path
         id: charm-path
-        run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
-
-      - name: Move built charm to charm directory
-        run: mv ${{ steps.charm-path.outputs.charm_path }} ${{ inputs.path }}
+        run: echo "charm_path=$(find ${{ inputs.path }} -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic


### PR DESCRIPTION
The action fails if the path is `./`, because it tries to move the built `.charm` artifact to the directory it is already present in. Example: https://github.com/canonical/tls-constraints-operator/actions/runs/14646739507/job/41103871389

This change downloads the artifact to the provided directory, and searches for it there instead, eliminating the need to move the file.

