### PR TITLE
feat: Add default Renovate configuration for reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # identity-credentials-workflows
 GitHub workflows for the Identity (Credentials) team
+
+## Renovate base configuration
+
+This repository contains a base Renovate configuration. To use it in other
+projects, create a `renovate.json5` file with the following content:
+
+```json
+{
+    "extends": ["github>canonical/identity-credentials-workflows/renovate.json5#v0"]
+}
+```

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":disableRateLimiting",
+    ":noUnscheduledUpdates",
+    ":semanticCommits"
+  ],
+  "automerge": true,
+  "automergeStrategy": "squash",
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "schedule": ["after 1am and before 3am every monday"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["after 1am and before 3am every wednesday"]
+  },
+  "timezone": "Etc/UTC",
+  "enabledManagers": ["pep621", "github-actions", "terraform"],
+  "packageRules": [
+    // Later rules override earlier rules
+    {
+      "matchManagers": ["pep621"],
+      "rangeStrategy": "bump",
+      "groupName": "Python dependencies"
+    },
+    {
+      // Disable updating Python, should be done when updating the Ubuntu base
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
+      // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
+      "matchPackageNames": ["pytest-asyncio"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub actions"
+    },
+    {
+      "matchManagers": ["terraform"],
+      "groupName": "Terraform"
+    },
+  ],
+}


### PR DESCRIPTION
Add a default Renovate configuration for reuse. It enables Python packages updates, except for pytest-asyncio and python itself. It also enables updates of Github Actions and terraform modules.

This will then be reused in other projects for simplified maintenance.