### PR TITLE
Add build for AMD only

### DIFF
--- a/.github/workflows/build-charm.yaml
+++ b/.github/workflows/build-charm.yaml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-charm-under-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: 5.21/stable
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive Charm Under Test
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm-amd64
+          path: "*.charm"
+          retention-days: 5


### PR DESCRIPTION
Add a build workflow that builds the charm on AMD only for cases when multiarch build is not desired.