### PR TITLE
feat: Add option to fetch latest charm libraries in TICS workflow

### DIFF
--- a/.github/workflows/tics-tox.yaml
+++ b/.github/workflows/tics-tox.yaml
@@ -13,7 +13,7 @@ on:
         default: '.'
         type: string
       fetch_libs:
-        description: 'Whether to fetch the latest charm libs'
+        description: 'Whether to fetch the charm libs defined in charmcraft.yaml'
         required: false
         type: boolean
         default: false
@@ -41,7 +41,7 @@ jobs:
           pipx install tox
           pipx inject tox tox-uv
 
-      - name: Fetch latest charm libraries
+      - name: Fetch charm libraries
         if: ${{ inputs.fetch_libs == true }}
         run: |
           charmcraft fetch-libs

--- a/.github/workflows/tics-tox.yaml
+++ b/.github/workflows/tics-tox.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         default: '.'
         type: string
+      fetch_libs:
+        description: 'Whether to fetch the latest charm libs'
+        required: false
+        type: boolean
+        default: false
     secrets:
       TICSAUTHTOKEN:
         required: true
@@ -27,14 +32,24 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y python3.10-venv pipx
 
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic
+
       - name: Install tox using pipx
         run: |
           pipx install tox
           pipx inject tox tox-uv
 
+      - name: Fetch latest charm libraries
+        if: ${{ inputs.fetch_libs == true }}
+        run: |
+          charmcraft fetch-libs
+
       - name: Run tox tests to create coverage.xml
         working-directory: ${{ inputs.dir }}
-        run: tox run -e unit
+        run: |
+          tox run -e unit
 
       - name: move results to necessary folder for TICS
         run: |


### PR DESCRIPTION
This is necessary to re-enable the TiCS workflow for https://github.com/canonical/self-signed-certificates-operator

See: https://github.com/canonical/self-signed-certificates-operator/actions/workflows/tics.yaml

Now that we fetch the libraries with charmcraft, instead of including them in the repo, we need to call `charmcraft fetch-libs`.

I weighed this against adding the command to the tox configuration, but it seems unnecessary to call it every time we want to run tests.