### PR TITLE
feat: Enable using charmcraftcache

### DIFF
--- a/.github/workflows/build-charm-multiarch.yaml
+++ b/.github/workflows/build-charm-multiarch.yaml
@@ -42,7 +42,7 @@ jobs:
             echo "$HOME/.local/bin" >> $GITHUB_PATH
           fi
           pipx install charmcraftcache
-          echo CHARMCRAFT_CACHE_BIN=ccc >> $GITHUB_ENV
+          echo CHARMCRAFT_BIN=ccc >> $GITHUB_ENV
 
       - name: Build charm under test
         run: ${{ env.CHARMCRAFT_BIN }} pack --verbose

--- a/.github/workflows/build-charm-multiarch.yaml
+++ b/.github/workflows/build-charm-multiarch.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-            channel: 5.21/stable
+          channel: 5.21/stable
 
       - name: Install charmcraft
         run: |
@@ -33,7 +33,15 @@ jobs:
       - name: Install charmcraft cache
         if: ${{ inputs.use-charmcraft-cache }}
         run: |
-          pip install charmcraftcache
+          # Ensure pipx is available
+          if ! command -v pipx &> /dev/null; then
+            # Install pipx via system package manager
+            sudo apt update && sudo apt install -y pipx
+            # Ensure pipx is in PATH
+            export PATH="$HOME/.local/bin:$PATH"
+            echo "$HOME/.local/bin" >> $GITHUB_PATH
+          fi
+          pipx install charmcraftcache
           echo CHARMCRAFT_CACHE_BIN=ccc >> $GITHUB_ENV
 
       - name: Build charm under test

--- a/.github/workflows/build-charm-multiarch.yaml
+++ b/.github/workflows/build-charm-multiarch.yaml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      use-charmcraft-cache:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-charm-under-test:
@@ -22,10 +27,17 @@ jobs:
             channel: 5.21/stable
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        run: |
+          sudo snap install charmcraft --classic
+          echo CHARMCRAFT_BIN=charmcraft >> $GITHUB_ENV
+      - name: Install charmcraft cache
+        if: ${{ inputs.use-charmcraft-cache }}
+        run: |
+          pip install charmcraftcache
+          echo CHARMCRAFT_CACHE_BIN=ccc >> $GITHUB_ENV
 
       - name: Build charm under test
-        run: charmcraft pack --verbose
+        run: ${{ env.CHARMCRAFT_BIN }} pack --verbose
 
       - name: Archive Charm Under Test
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR will allow calling the build workflow with charmcraft-cache enabled. The cache is not used by default.