### PR TITLE
feat: Allow uv.lock file location to be configured

### DIFF
--- a/.github/workflows/uv-scan.yaml
+++ b/.github/workflows/uv-scan.yaml
@@ -3,6 +3,13 @@ name: Trivy Vulnerability Scanner
 
 on:
   workflow_call:
+    inputs:
+      uv-lock-path:
+        description: 'Path to uv.lock file'
+        required: false
+        type: string
+        default: 'uv.lock'
+
 
 permissions:
   security-events: write
@@ -33,7 +40,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.33.1
         with:
           scan-type: 'fs'
-          scan-ref: 'uv.lock'
+          scan-ref: ${{ inputs.uv-lock-path }}
           version: 'v0.61.0'
           format: 'sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
This will allow use re-use the workflow for monorepos like the Vault charms which have multiple `uv.lock` files that aren't necessarily in the root directory.