### PR TITLE
Refresh locks every monday and ignore rpds-py

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,7 +8,7 @@
   schedule: ["at any time"],
   lockFileMaintenance: {
     enabled: true,
-    schedule: ["at any time"],
+    schedule: ["before 4am on monday"],
   },
   timezone: "Etc/UTC",
   enabledManagers: ["pep621", "github-actions", "terraform"],
@@ -27,6 +27,12 @@
     {
       // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
       matchPackageNames: ["pytest-asyncio"],
+      matchUpdateTypes: ["minor"],
+      enabled: false,
+    },
+    {
+      // Bumping "rpds" over 0.27 breaks the unit tests with Pydantic V1
+      matchPackageNames: ["rpds-py"],
       matchUpdateTypes: ["minor"],
       enabled: false,
     },


### PR DESCRIPTION
The lock refresh is creating a lot of noise, and doing it every day is not really necessary.

The rpds update breaks Pydantic V1, so we need to avoid doing that since we still run tests against Pydantic V1. Although this may soon change since we are moving away from charm libraries, we may as well disable them now to avoid the noise.