### PR TITLE
Revert "chore(deps): update github actions"

### DIFF
--- a/.github/workflows/tics-tox.yaml
+++ b/.github/workflows/tics-tox.yaml
@@ -57,7 +57,7 @@ jobs:
           mv ${{ inputs.dir }}/coverage.xml ${{ inputs.dir }}/cover/coverage.xml
 
       - name: Run TICS analysis with github-action
-        uses: tiobe/tics-github-action@a53037a6bb9f71b6a97cdeb0ac41632266804b9e # v3
+        uses: tiobe/tics-github-action@768de18bedf164ee461bc9ef5e2f2fa1a20b122a # v3
         with:
           mode: qserver
           project: ${{ inputs.project}}

--- a/.github/workflows/uv-scan.yaml
+++ b/.github/workflows/uv-scan.yaml
@@ -21,7 +21,7 @@ jobs:
 
 
       - name: Run Trivy vulnerability scanner (table format)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.uv-lock-path}}
@@ -31,7 +31,7 @@ jobs:
           scanners: 'vuln'
 
       - name: Run Trivy vulnerability scanner (SARIF format)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.uv-lock-path }}


### PR DESCRIPTION
this should probably be merged to v1. why do we even have different branches when we tag the release commits already?