### PR TITLE
fix: downgrade go version used by grafana

### DIFF
--- a/.github/workflows/grafana-dashboard-lint-report.yaml
+++ b/.github/workflows/grafana-dashboard-lint-report.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.25'
 
       - name: Install Grafana Dashboard Linter
         run: go install github.com/grafana/dashboard-linter@latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - v1
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
go 1.26 is incompatible with grafana, this undoes the renovate PR that did updated the version