### PR TITLE
fix: correct Trivy/CodeQL SHA pins and drop reserved GITHUB_TOKEN input

### DIFF
--- a/.github/workflows/rock-publish.yaml
+++ b/.github/workflows/rock-publish.yaml
@@ -41,9 +41,6 @@ on:
         required: false
         default: .
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   publish:

--- a/.github/workflows/rock-scan.yaml
+++ b/.github/workflows/rock-scan.yaml
@@ -35,9 +35,6 @@ on:
         required: false
         default: HIGH,CRITICAL
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   scan:
@@ -107,7 +104,7 @@ jobs:
 
       - name: Upload SARIF results
         if: always()
-        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d9926d061cc75be # v3
+        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           sarif_file: "trivy-results-${{ inputs.arch }}.sarif"
           category: "Trivy Rock Scan (${{ inputs.arch }})"

--- a/.github/workflows/uv-scan.yaml
+++ b/.github/workflows/uv-scan.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Run Trivy vulnerability scanner (table format)
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f91f1525241e3c28c60f # v0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.path }}/${{ inputs.uv-lock-path }}
@@ -38,7 +38,7 @@ jobs:
           scanners: 'vuln'
 
       - name: Run Trivy vulnerability scanner (SARIF format)
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f91f1525241e3c28c60f # v0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.path }}/${{ inputs.uv-lock-path }}
@@ -49,7 +49,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d9926d061cc75be # v3
+        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           sarif_file: "trivy-results.sarif"
           category: "Trivy Vulnerability Scan"


### PR DESCRIPTION
correct Trivy/CodeQL SHA pins and drop reserved GITHUB_TOKEN input