### PR TITLE
fix: print resulting folder for builds

### DIFF
--- a/common.just
+++ b/common.just
@@ -365,6 +365,7 @@ build-snap:
 
     snapcraft pack --verbose
     mv "$(ls *.snap 2>/dev/null | head -n 1)" "$(ls *.snap 2>/dev/null | head -n 1 | sed -E 's/^([^_]+)_[^_]+_([^_]+)\.snap$/\1-\2.snap/')"
+    ls
 
 [private]
 build-rock:
@@ -373,6 +374,7 @@ build-rock:
 
     rockcraft pack --verbose
     mv "$(ls *.rock 2>/dev/null | head -n 1)" "$(ls *.rock 2>/dev/null | head -n 1 | sed -E 's/^([^_]+)_[^_]+_([^_]+)\.rock$/\1-\2.rock/')"
+    ls
 
 # =============================================================================
 # Integration Testing


### PR DESCRIPTION
this PR prints resulting files once a build is complete.