### PR TITLE
fix: bump pinned Trivy version in uv-scan.yaml to v0.74.0

### DIFF
--- a/.github/workflows/uv-scan.yaml
+++ b/.github/workflows/uv-scan.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.path }}/${{ inputs.uv-lock-path }}
-          version: 'v0.71.1'
+          version: 'v0.74.0'
           format: 'table'
           severity: ${{ inputs.severity }}
           scanners: 'vuln'
@@ -42,7 +42,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.path }}/${{ inputs.uv-lock-path }}
-          version: 'v0.71.1'
+          version: 'v0.74.0'
           format: 'sarif'
           severity: ${{ inputs.severity }}
           scanners: 'vuln'


### PR DESCRIPTION
## Problem

`uv-scan.yaml` pins a Trivy `version:` for `aquasecurity/trivy-action`'s
install step. The version most recently in use (`v0.58.0`, and even
`v0.71.1` picked up by a `chore(deps)` renovate commit that didn't trigger
a release) no longer has compiled binary assets published on its GitHub
release — only the source archive remains.

This makes every downstream consumer's "Install Trivy" step resolve the
tag fine, then fail to download the binary:

```
aquasecurity/trivy info checking GitHub for tag 'v0.58.0'
aquasecurity/trivy info found version: 0.58.0 for v0.58.0/Linux/64bit
Error: Process completed with exit code 1.
```

Seen failing in `canonical/lego-operator`'s Trivy workflow (calling
`uv-scan.yaml@v3.1.3`).

## Fix

Bump the pinned Trivy `version:` to `v0.74.0` (latest release with
binary assets currently published) as a `fix:` commit, so release-please
picks it up and cuts a new tag that consumers can pin to.